### PR TITLE
Fix code scanning alert no. 7: Database query built from user-controlled sources

### DIFF
--- a/storeApi/controllers/products.js
+++ b/storeApi/controllers/products.js
@@ -5,7 +5,7 @@ const getAllProducts = async (req, res) => {
   const queryObject = {};
   if (featured) queryObject.featured = featured === "true" ? true : false;
 
-  if (company) queryObject.company = company;
+  if (company) queryObject.company = { $eq: company };
 
   if (name) queryObject.name = { $regex: name, $options: "i" };
 


### PR DESCRIPTION
Fixes [https://github.com/Noureldin2303/Nodejs-starter-projects/security/code-scanning/7](https://github.com/Noureldin2303/Nodejs-starter-projects/security/code-scanning/7)

To fix the problem, we need to ensure that the `company` parameter is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query to ensure that the user input is interpreted as a literal value. This change will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
